### PR TITLE
Add {console} tag

### DIFF
--- a/src/Ad5001/Functions/Main.php
+++ b/src/Ad5001/Functions/Main.php
@@ -148,6 +148,9 @@
             }
             if($cmd === "tell " . $sender->getName() . " This is default command, modify it with /function setc <function> <Command number> <command...>"){
               $this->getServer()->dispatchCommand(new ConsoleCommandSender(), $cmd);
+            }elseif(strpos($cmd, "{console}")){
+              $cmd = str_ireplace("{console}", "", $cmd);
+              $this->getServer()->dispatchCommand(new ConsoleCommandSender(), $cmd);
             }else{
               this->getServer()->dispatchCommand($sender, $cmd);
             }


### PR DESCRIPTION
By putting {console} in your command, it now runs as the console when the player types the command. This has **NOT** been tested.
