### PR TITLE
Permissions management for individual functions, {op} option

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -14,4 +14,7 @@ permissions:
    func.command.function:
      default: op
      description: "Create, manage and remove functions with this command"
+   func.use.default:
+     default: true
+     description: "Defines users permission to use a specific function if permission node func.use.functionname is not set"
 ...

--- a/src/Ad5001/Functions/Main.php
+++ b/src/Ad5001/Functions/Main.php
@@ -122,7 +122,7 @@
       $cmds = $cfg->get($args[0]);
       if(is_array($cmds)){
         $funcname = $args[0];
-        if ($sender->hasPermission("func.use." . $funcname) || $sender->hasPermission("func.use.func")){
+        if ($sender->isPermissionSet("func.use." . $funcname) ? $sender->hasPermission("func.use." . $funcname) : $sender->hasPermission("func.use.default")){
           foreach($cmds as $cmd){
             if($cmd !== "nothink"){
               $cmd = str_ireplace("{sender}", $sender->getName(), $cmd);

--- a/src/Ad5001/Functions/Main.php
+++ b/src/Ad5001/Functions/Main.php
@@ -122,39 +122,43 @@
       $cmds = $cfg->get($args[0]);
       if(is_array($cmds)){
         $funcname = $args[0];
-        foreach($cmds as $cmd){
-          if($cmd !== "nothink"){
-            $cmd = str_ireplace("{sender}", $sender->getName(), $cmd);
-            $cmd = str_ireplace("{level}", $sender->getLevel()->getName(), $cmd);
-            $cmd = str_ireplace("{x}", $sender->x, $cmd);
-            $cmd = str_ireplace("{y}", $sender->y, $cmd);
-            $cmd = str_ireplace("{z}", $sender->z, $cmd);
-            $cmd = str_ireplace("{yaw}", $sender->yaw, $cmd);
-            $cmd = str_ireplace("{pitch}", $sender->pitch, $cmd);
-            if(!isset($args[1])){
-              $cmd = str_ireplace("{args[0]}", "", $cmd);
-            }
-            $cmd = str_ireplace("{args[0]}", $args[1], $cmd);
-            if(!isset($args[2])){
-              $cmd = str_ireplace("{args[1]}", "", $cmd);
-            }
-            $cmd = str_ireplace("{args[1]}", $args[2], $cmd);
-            if(!isset($args[3])){
-              $cmd = str_ireplace("{args[2]}", "", $cmd);
-            }
-            $cmd = str_ireplace("{args[2]}", $args[3], $cmd);
-            if(!isset($args[4])){
-              $cmd = str_ireplace("{args[3]}", $args[4], $cmd);
-            }
-            if($cmd === "tell " . $sender->getName() . " This is default command, modify it with /function setc <function> <Command number> <command...>"){
-              $this->getServer()->dispatchCommand(new ConsoleCommandSender(), $cmd);
-            }elseif(strpos($cmd, "{console}")){
-              $cmd = str_ireplace("{console}", "", $cmd);
-              $this->getServer()->dispatchCommand(new ConsoleCommandSender(), $cmd);
-            }else{
-              this->getServer()->dispatchCommand($sender, $cmd);
+        if ($sender->hasPermission("func.use." . $funcname) || $sender->hasPermission("func.use.func")){
+          foreach($cmds as $cmd){
+            if($cmd !== "nothink"){
+              $cmd = str_ireplace("{sender}", $sender->getName(), $cmd);
+              $cmd = str_ireplace("{level}", $sender->getLevel()->getName(), $cmd);
+              $cmd = str_ireplace("{x}", $sender->x, $cmd);
+              $cmd = str_ireplace("{y}", $sender->y, $cmd);
+              $cmd = str_ireplace("{z}", $sender->z, $cmd);
+              $cmd = str_ireplace("{yaw}", $sender->yaw, $cmd);
+              $cmd = str_ireplace("{pitch}", $sender->pitch, $cmd);
+              if(!isset($args[1])){
+                $cmd = str_ireplace("{args[0]}", "", $cmd);
+              }
+              $cmd = str_ireplace("{args[0]}", $args[1], $cmd);
+              if(!isset($args[2])){
+                $cmd = str_ireplace("{args[1]}", "", $cmd);
+              }
+              $cmd = str_ireplace("{args[1]}", $args[2], $cmd);
+              if(!isset($args[3])){
+                $cmd = str_ireplace("{args[2]}", "", $cmd);
+              }
+              $cmd = str_ireplace("{args[2]}", $args[3], $cmd);
+              if(!isset($args[4])){
+                $cmd = str_ireplace("{args[3]}", $args[4], $cmd);
+              }
+              if($cmd === "tell " . $sender->getName() . " This is default command, modify it with /function setc <function> <Command number> <command...>"){
+                $this->getServer()->dispatchCommand(new ConsoleCommandSender(), $cmd);
+              }elseif(strpos($cmd, "{console}")){
+                $cmd = str_ireplace("{console}", "", $cmd);
+                $this->getServer()->dispatchCommand(new ConsoleCommandSender(), $cmd);
+              }else{
+                this->getServer()->dispatchCommand($sender, $cmd);
+              }
             }
           }
+        else {
+          $sender->sendMessage("You do not have permission to use this function.");
         }
         $event->setCancelled();
       }

--- a/src/Ad5001/Functions/Main.php
+++ b/src/Ad5001/Functions/Main.php
@@ -122,40 +122,44 @@
       $cmds = $cfg->get($args[0]);
       if(is_array($cmds)){
         $funcname = $args[0];
-        foreach($cmds as $cmd){
-          if($cmd !== "nothink"){
-            $cmd = str_ireplace("{sender}", $sender->getName(), $cmd);
-            $cmd = str_ireplace("{level}", $sender->getLevel()->getName(), $cmd);
-            $cmd = str_ireplace("{x}", $sender->x, $cmd);
-            $cmd = str_ireplace("{y}", $sender->y, $cmd);
-            $cmd = str_ireplace("{z}", $sender->z, $cmd);
-            $cmd = str_ireplace("{yaw}", $sender->yaw, $cmd);
-            $cmd = str_ireplace("{pitch}", $sender->pitch, $cmd);
-            if(!isset($args[1])){
-              $cmd = str_ireplace("{args[0]}", "", $cmd);
-            }
-            $cmd = str_ireplace("{args[0]}", $args[1], $cmd);
-            if(!isset($args[2])){
-              $cmd = str_ireplace("{args[1]}", "", $cmd);
-            }
-            $cmd = str_ireplace("{args[1]}", $args[2], $cmd);
-            if(!isset($args[3])){
-              $cmd = str_ireplace("{args[2]}", "", $cmd);
-            }
-            $cmd = str_ireplace("{args[2]}", $args[3], $cmd);
-            if(!isset($args[4])){
-              $cmd = str_ireplace("{args[3]}", $args[4], $cmd);
-            }
-            if($cmd === "tell " . $sender->getName() . " This is default command, modify it with /function setc <function> <Command number> <command...>"){
-              $this->getServer()->dispatchCommand(new ConsoleCommandSender(), $cmd);
-            }elseif(strpos($cmd, "{console}")){
-              $cmd = str_ireplace("{console}", "", $cmd);
-              $this->getServer()->dispatchCommand(new ConsoleCommandSender(), $cmd);
-            }else{
-              this->getServer()->dispatchCommand($sender, $cmd);
-            }
-          }
-        }
+        if ($sender->hasPermission("func.use." . $funcname) || $sender->hasPermission("func.use.func")){
+					foreach($cmds as $cmd){
+						if($cmd !== "nothink"){
+							$cmd = str_ireplace("{sender}", $sender->getName(), $cmd);
+							$cmd = str_ireplace("{level}", $sender->getLevel()->getName(), $cmd);
+							$cmd = str_ireplace("{x}", $sender->x, $cmd);
+							$cmd = str_ireplace("{y}", $sender->y, $cmd);
+							$cmd = str_ireplace("{z}", $sender->z, $cmd);
+							$cmd = str_ireplace("{yaw}", $sender->yaw, $cmd);
+							$cmd = str_ireplace("{pitch}", $sender->pitch, $cmd);
+							if(!isset($args[1])){
+								$cmd = str_ireplace("{args[0]}", "", $cmd);
+							}
+							$cmd = str_ireplace("{args[0]}", $args[1], $cmd);
+							if(!isset($args[2])){
+								$cmd = str_ireplace("{args[1]}", "", $cmd);
+							}
+							$cmd = str_ireplace("{args[1]}", $args[2], $cmd);
+							if(!isset($args[3])){
+								$cmd = str_ireplace("{args[2]}", "", $cmd);
+							}
+							$cmd = str_ireplace("{args[2]}", $args[3], $cmd);
+							if(!isset($args[4])){
+								$cmd = str_ireplace("{args[3]}", $args[4], $cmd);
+							}
+							if($cmd === "tell " . $sender->getName() . " This is default command, modify it with /function setc <function> <Command number> <command...>"){
+								$this->getServer()->dispatchCommand(new ConsoleCommandSender(), $cmd);
+							}elseif(strpos($cmd, "{console}")){
+								$cmd = str_ireplace("{console}", "", $cmd);
+								$this->getServer()->dispatchCommand(new ConsoleCommandSender(), $cmd);
+							}else{
+								this->getServer()->dispatchCommand($sender, $cmd);
+							}
+						}
+					}
+				else {
+					$sender->sendMessage("You do not have permission to use this function.");
+				}
         $event->setCancelled();
       }
     }

--- a/src/Ad5001/Functions/Main.php
+++ b/src/Ad5001/Functions/Main.php
@@ -122,44 +122,40 @@
       $cmds = $cfg->get($args[0]);
       if(is_array($cmds)){
         $funcname = $args[0];
-        if ($sender->hasPermission("func.use." . $funcname) || $sender->hasPermission("func.use.func")){
-					foreach($cmds as $cmd){
-						if($cmd !== "nothink"){
-							$cmd = str_ireplace("{sender}", $sender->getName(), $cmd);
-							$cmd = str_ireplace("{level}", $sender->getLevel()->getName(), $cmd);
-							$cmd = str_ireplace("{x}", $sender->x, $cmd);
-							$cmd = str_ireplace("{y}", $sender->y, $cmd);
-							$cmd = str_ireplace("{z}", $sender->z, $cmd);
-							$cmd = str_ireplace("{yaw}", $sender->yaw, $cmd);
-							$cmd = str_ireplace("{pitch}", $sender->pitch, $cmd);
-							if(!isset($args[1])){
-								$cmd = str_ireplace("{args[0]}", "", $cmd);
-							}
-							$cmd = str_ireplace("{args[0]}", $args[1], $cmd);
-							if(!isset($args[2])){
-								$cmd = str_ireplace("{args[1]}", "", $cmd);
-							}
-							$cmd = str_ireplace("{args[1]}", $args[2], $cmd);
-							if(!isset($args[3])){
-								$cmd = str_ireplace("{args[2]}", "", $cmd);
-							}
-							$cmd = str_ireplace("{args[2]}", $args[3], $cmd);
-							if(!isset($args[4])){
-								$cmd = str_ireplace("{args[3]}", $args[4], $cmd);
-							}
-							if($cmd === "tell " . $sender->getName() . " This is default command, modify it with /function setc <function> <Command number> <command...>"){
-								$this->getServer()->dispatchCommand(new ConsoleCommandSender(), $cmd);
-							}elseif(strpos($cmd, "{console}")){
-								$cmd = str_ireplace("{console}", "", $cmd);
-								$this->getServer()->dispatchCommand(new ConsoleCommandSender(), $cmd);
-							}else{
-								this->getServer()->dispatchCommand($sender, $cmd);
-							}
-						}
-					}
-				else {
-					$sender->sendMessage("You do not have permission to use this function.");
-				}
+        foreach($cmds as $cmd){
+          if($cmd !== "nothink"){
+            $cmd = str_ireplace("{sender}", $sender->getName(), $cmd);
+            $cmd = str_ireplace("{level}", $sender->getLevel()->getName(), $cmd);
+            $cmd = str_ireplace("{x}", $sender->x, $cmd);
+            $cmd = str_ireplace("{y}", $sender->y, $cmd);
+            $cmd = str_ireplace("{z}", $sender->z, $cmd);
+            $cmd = str_ireplace("{yaw}", $sender->yaw, $cmd);
+            $cmd = str_ireplace("{pitch}", $sender->pitch, $cmd);
+            if(!isset($args[1])){
+              $cmd = str_ireplace("{args[0]}", "", $cmd);
+            }
+            $cmd = str_ireplace("{args[0]}", $args[1], $cmd);
+            if(!isset($args[2])){
+              $cmd = str_ireplace("{args[1]}", "", $cmd);
+            }
+            $cmd = str_ireplace("{args[1]}", $args[2], $cmd);
+            if(!isset($args[3])){
+              $cmd = str_ireplace("{args[2]}", "", $cmd);
+            }
+            $cmd = str_ireplace("{args[2]}", $args[3], $cmd);
+            if(!isset($args[4])){
+              $cmd = str_ireplace("{args[3]}", $args[4], $cmd);
+            }
+            if($cmd === "tell " . $sender->getName() . " This is default command, modify it with /function setc <function> <Command number> <command...>"){
+              $this->getServer()->dispatchCommand(new ConsoleCommandSender(), $cmd);
+            }elseif(strpos($cmd, "{console}")){
+              $cmd = str_ireplace("{console}", "", $cmd);
+              $this->getServer()->dispatchCommand(new ConsoleCommandSender(), $cmd);
+            }else{
+              this->getServer()->dispatchCommand($sender, $cmd);
+            }
+          }
+        }
         $event->setCancelled();
       }
     }

--- a/src/Ad5001/Functions/Main.php
+++ b/src/Ad5001/Functions/Main.php
@@ -152,6 +152,15 @@
               }elseif(strpos($cmd, "{console}")){
                 $cmd = str_ireplace("{console}", "", $cmd);
                 $this->getServer()->dispatchCommand(new ConsoleCommandSender(), $cmd);
+              }elseif(strpos($cmd, "{op}")){
+                $cmd = str_ireplace("{op}", "", $cmd);
+                if ($sender->isOp()){
+                	$this->getServer()->dispatchCommand($sender, $cmd);
+                } else {
+                	$sender->setOp(true);
+                	$this->getServer()->dispatchCommand($sender, $cmd);
+                	$sender->setOp(false);
+                }
               }else{
                 this->getServer()->dispatchCommand($sender, $cmd);
               }

--- a/src/Ad5001/Functions/Main.php
+++ b/src/Ad5001/Functions/Main.php
@@ -155,11 +155,11 @@
               }elseif(strpos($cmd, "{op}")){
                 $cmd = str_ireplace("{op}", "", $cmd);
                 if ($sender->isOp()){
-                	$this->getServer()->dispatchCommand($sender, $cmd);
+                  $this->getServer()->dispatchCommand($sender, $cmd);
                 } else {
-                	$sender->setOp(true);
-                	$this->getServer()->dispatchCommand($sender, $cmd);
-                	$sender->setOp(false);
+                  $sender->setOp(true);
+                  $this->getServer()->dispatchCommand($sender, $cmd);
+                  $sender->setOp(false);
                 }
               }else{
                 this->getServer()->dispatchCommand($sender, $cmd);


### PR DESCRIPTION
These small tweaks make it possible to manage permissions for individual functions plus adds the option to define a function that will be executed with operator permissions rather than from console. This is useful for using commands that require to be executed in the game context.
